### PR TITLE
:NORMAL: Fix/remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 
 	dependencies {
@@ -20,7 +20,7 @@ ext {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 
 		maven {
 			url 'http://oss.3sidedcube.com:8081/artifactory/internal'

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 
 ext {
 	minSdkVersion = 16
-	compileSdkVersion = 30
-	targetSdkVersion = 30
+	compileSdkVersion = 31
+	targetSdkVersion = 31
 }
 
 allprojects {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 	implementation project(':library')
 
-	implementation 'androidx.appcompat:appcompat:1.2.0'
 	implementation 'com.3sidedcube.storm:ui:1.4.0-SNAPSHOT'
 
 	compileOnly 'org.projectlombok:lombok:1.18.12'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,6 +9,7 @@ android {
 		applicationId "com.cube.storm.ui.quiz.example"
 		minSdkVersion rootProject.ext.minSdkVersion
 		targetSdkVersion rootProject.ext.targetSdkVersion
+		multiDexEnabled true
 	}
 
 	compileOptions {
@@ -25,7 +26,8 @@ dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 	implementation project(':library')
 
-	implementation 'com.3sidedcube.storm:ui:1.4.0-SNAPSHOT'
+	implementation 'androidx.multidex:multidex:2.0.1'
+	implementation 'com.3sidedcube.storm:ui:1.7.0'
 
 	compileOnly 'org.projectlombok:lombok:1.18.12'
 	annotationProcessor 'org.projectlombok:lombok:1.18.12'

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,21 +1,28 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
-	package="com.cube.storm.quiz.example"
->
+	package="com.cube.storm.quiz.example">
+
 	<application
 		android:allowBackup="true"
 		android:name=".MainApplication"
-		tools:ignore="AllowBackup,GoogleAppIndexingWarning,MissingApplicationIcon"
-	>
-		<activity android:name=".ExampleActivity">
+		tools:ignore="AllowBackup,GoogleAppIndexingWarning,MissingApplicationIcon">
+		<activity
+			android:exported="true"
+			android:name=".ExampleActivity">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
 
-		<activity android:name="com.cube.storm.ui.quiz.activity.StormQuizActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
-		<activity android:name="com.cube.storm.ui.quiz.activity.StormQuizResultsActivity" android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+		<activity
+			android:exported="false"
+			android:name="com.cube.storm.ui.quiz.activity.StormQuizActivity"
+			android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+		<activity
+			android:exported="false"
+			android:name="com.cube.storm.ui.quiz.activity.StormQuizResultsActivity"
+			android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
 	</application>
 </manifest>

--- a/example/src/main/java/com/cube/storm/quiz/example/MainApplication.java
+++ b/example/src/main/java/com/cube/storm/quiz/example/MainApplication.java
@@ -1,6 +1,5 @@
 package com.cube.storm.quiz.example;
 
-import android.app.Application;
 import android.net.Uri;
 import com.cube.storm.UiSettings;
 import com.cube.storm.ui.QuizSettings;
@@ -11,7 +10,9 @@ import com.google.gson.reflect.TypeToken;
 
 import java.util.ArrayList;
 
-public class MainApplication extends Application
+import androidx.multidex.MultiDexApplication;
+
+public class MainApplication extends MultiDexApplication
 {
 	@Override public void onCreate()
 	{

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.3.0
+VERSION_NAME=1.4.0
 GROUP=com.3sidedcube.storm
 
 POM_NAME=LightningQuiz

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,12 +21,18 @@ android {
 }
 
 dependencies {
+	// Android components
 	implementation 'androidx.annotation:annotation:1.1.0'
 	implementation 'androidx.legacy:legacy-support-v13:1.0.0'
 	implementation 'androidx.cardview:cardview:1.0.0'
+	implementation 'androidx.appcompat:appcompat:1.4.0'
+	implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
+	// Other Storm components
 	implementation 'com.3sidedcube.storm:ui:1.4.0-SNAPSHOT'
+	implementation 'com.3sidedcube.storm:util:1.2.0'
 
+	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.12'
 	annotationProcessor 'org.projectlombok:lombok:1.18.12'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
 	// Other Storm components
-	implementation 'com.3sidedcube.storm:ui:1.4.0-SNAPSHOT'
+	implementation 'com.3sidedcube.storm:ui:1.7.0'
 	implementation 'com.3sidedcube.storm:util:1.2.0'
 
 	// Lombok

--- a/library/src/main/java/com/cube/storm/ui/quiz/model/page/QuizPage.java
+++ b/library/src/main/java/com/cube/storm/ui/quiz/model/page/QuizPage.java
@@ -1,6 +1,8 @@
 package com.cube.storm.ui.quiz.model.page;
 
 import android.os.Parcel;
+
+import com.cube.storm.ui.model.Model;
 import com.cube.storm.ui.model.page.Page;
 import com.cube.storm.ui.model.property.LinkProperty;
 import com.cube.storm.ui.model.property.TextProperty;
@@ -68,5 +70,10 @@ public class QuizPage extends Page
 	@Override public void writeToParcel(Parcel dest, int flags)
 	{
 
+	}
+	
+	@Override public Collection <? extends Model> getAudio()
+	{
+		return null;
 	}
 }


### PR DESCRIPTION
### What?

- Increase the target and compile SDK versions to 31
    - This includes updating the example app `AndroidManifest.xml` so that `android:exported` is explicitly specified for each activity
- Update several dependencies so that the library works with version 31 and storm UI version 1.7.0
    - This includes updating `QuizPage.java` to override the `getAudio()` method, introduced in v1.4.1
    - It also includes enabling multidex for the example app
- Remove the `jcenter()` repository, and replace it with `mavenCentral()`
- Bump the version to 1.4.0

### Why?
jcenter is deprecated, and has been having a lot of downtime recently.
Therefore, we are removing it, in order to make builds more stable.

### Testing
These changes were published privately as version 1.4.0-rc1, and tested on an app with jcenter removed from it.
It worked as intended.