### PR TITLE
:NORMAL: Feature/image quiz item localisation

### DIFF
--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -37,6 +37,7 @@ afterEvaluate { project ->
 	publishing {
 		publications {
 			mavenJava(MavenPublication) {
+				from components.release
 				groupId = GROUP
 				artifactId = POM_ARTIFACT_ID
 				version = VERSION_NAME

--- a/library/src/main/java/com/cube/storm/ui/quiz/view/holder/ImageQuizItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/quiz/view/holder/ImageQuizItemViewHolder.java
@@ -18,6 +18,8 @@ import com.cube.storm.ui.view.holder.ViewHolderFactory;
 
 import java.util.ArrayList;
 
+import androidx.annotation.Nullable;
+
 /**
  * View holder for {@link com.cube.storm.ui.quiz.model.quiz.ImageQuizItem} in the adapter
  *
@@ -124,15 +126,17 @@ public class ImageQuizItemViewHolder extends ViewHolder<ImageQuizItem>
 
 		// Set image label style and its background
 		TextView textView = answerLayout.findViewById(R.id.label);
+		CharSequence labelText = null;
 		if (textView != null)
 		{
 			textView.setTextAppearance(answerLayout.getContext(),
 				selectAnswer ? R.style.QuizImageLabel_Selected : R.style.QuizImageLabel_Unselected);
 			textView.setBackgroundResource(selectAnswer ? R.drawable.quiz_image_label_selected_border : 0);
+			labelText = textView.getText();
 		}
 
 		// Update the content description based on the selected answer and label text
-		updateAnswerContentDescription(answerLayout, textView.getText(), selectAnswer);
+		updateAnswerContentDescription(answerLayout, labelText, selectAnswer);
 	}
 	
 	/**
@@ -141,8 +145,12 @@ public class ImageQuizItemViewHolder extends ViewHolder<ImageQuizItem>
 	 * @param baseText the base label text of the view
 	 * @param selectAnswer if answer is selected or unselected
 	 */
-	protected void updateAnswerContentDescription(View answerLayout, CharSequence baseText, boolean selectAnswer)
+	protected void updateAnswerContentDescription(View answerLayout, @Nullable CharSequence baseText, boolean selectAnswer)
 	{
+		if(baseText == null)
+		{
+			baseText = "";
+		}
 		answerLayout.setContentDescription(baseText + (selectAnswer ? " selected" : " not selected"));
 	}
 

--- a/library/src/main/java/com/cube/storm/ui/quiz/view/holder/ImageQuizItemViewHolder.java
+++ b/library/src/main/java/com/cube/storm/ui/quiz/view/holder/ImageQuizItemViewHolder.java
@@ -131,7 +131,19 @@ public class ImageQuizItemViewHolder extends ViewHolder<ImageQuizItem>
 			textView.setBackgroundResource(selectAnswer ? R.drawable.quiz_image_label_selected_border : 0);
 		}
 
-		answerLayout.setContentDescription(textView.getText() + (selectAnswer ? " selected" : " not selected"));
+		// Update the content description based on the selected answer and label text
+		updateAnswerContentDescription(answerLayout, textView.getText(), selectAnswer);
+	}
+	
+	/**
+	 * Updates the view content description changes when an image answer is selected or unselected
+	 * @param answerLayout the layout container other views
+	 * @param baseText the base label text of the view
+	 * @param selectAnswer if answer is selected or unselected
+	 */
+	protected void updateAnswerContentDescription(View answerLayout, CharSequence baseText, boolean selectAnswer)
+	{
+		answerLayout.setContentDescription(baseText + (selectAnswer ? " selected" : " not selected"));
 	}
 
 	private class ModelClickListener implements OnClickListener


### PR DESCRIPTION
### What?
- Factors out new protected `ImageQuizItemViewHolder.updateAnswerContentDescription` method
- Fixes calling `textView.getText()` outside of the `if (textView != null)` block

### Why?
- Enables apps using this library to more easily customise the content descriptions (e.g localise them) by overriding just the single protected method
- Avoids potential crashes with `NullPointerException`s by calling `getText()` on a potentially null `textView`